### PR TITLE
Add unit tests for token embedder and seq2labels model

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+    - name: Test
+      run: |
+        pytest -v tests

--- a/tests/test_bert_embedder.py
+++ b/tests/test_bert_embedder.py
@@ -5,8 +5,7 @@ from allennlp.common.testing import ModelTestCase
 from allennlp.data.dataset import Batch
 from allennlp.data.fields import TextField
 from allennlp.data.instance import Instance
-from allennlp.data.tokenizers import WordTokenizer
-from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
+from allennlp.data import Token
 from allennlp.data.vocabulary import Vocabulary
 from gector.bert_token_embedder import PretrainedBertEmbedder
 from gector.tokenizer_indexer import PretrainedBertIndexer
@@ -16,11 +15,10 @@ class TestPretrainedBertEmbedder(ModelTestCase):
     """Test token embedder for BERT model."""
 
     def setUp(self):
-        """Set up tokenizer and indexer."""
+        """Set up indexer."""
 
         super().setUp()
 
-        self.tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
         vocab_path = "data/output_vocabulary"
         self.vocab = Vocabulary.from_files(vocab_path)
         self.model_name = "bert-base-cased"
@@ -97,10 +95,10 @@ class TestPretrainedBertEmbedder(ModelTestCase):
         """Test token embedder end-to-end."""
 
         sentence1 = "the quickest quick brown fox jumped over the lazy dog"
-        tokens1 = self.tokenizer.tokenize(sentence1)
+        tokens1 = [Token(word) for word in sentence1.split()]
 
         sentence2 = "the quick brown fox jumped over the laziest lazy elmo"
-        tokens2 = self.tokenizer.tokenize(sentence2)
+        tokens2 = [Token(word) for word in sentence2.split()]
 
         instance1 = Instance(
             {"tokens": TextField(tokens1, {"bert": self.token_indexer})}
@@ -193,7 +191,7 @@ class TestPretrainedBertEmbedder(ModelTestCase):
         )
 
         sentence = "the " * 512
-        tokens = self.tokenizer.tokenize(sentence)
+        tokens = [Token(word) for word in sentence.split()]
 
         instance = Instance(
             {"tokens": TextField(tokens, {"bert": self.token_indexer})}
@@ -218,7 +216,7 @@ class TestPretrainedBertEmbedder(ModelTestCase):
         )
 
         sentence = "the " * 514
-        tokens = self.tokenizer.tokenize(sentence)
+        tokens = [Token(word) for word in sentence.split()]
 
         instance = Instance(
             {"tokens": TextField(tokens, {"bert": self.token_indexer})}

--- a/tests/test_bert_embedder.py
+++ b/tests/test_bert_embedder.py
@@ -181,7 +181,7 @@ class TestPretrainedBertEmbedder(ModelTestCase):
         assert list(bert_vectors.shape) == [2, 10, 768]
 
     def test_max_length(self):
-        """Test that max input length works."""
+        """Test that max input length works (default max len = 512)."""
 
         token_embedder = PretrainedBertEmbedder(
             self.model_name,
@@ -206,7 +206,7 @@ class TestPretrainedBertEmbedder(ModelTestCase):
         token_embedder(tokens["bert"], tokens["bert-offsets"])
 
     def test_max_length_raise_error(self):
-        """Test that input greater than max length raises error."""
+        """Test that input greater than max length (default = 512) raises error."""
 
         token_embedder = PretrainedBertEmbedder(
             self.model_name,

--- a/tests/test_bert_embedder.py
+++ b/tests/test_bert_embedder.py
@@ -1,0 +1,234 @@
+import torch
+import pytest
+
+from allennlp.common.testing import ModelTestCase
+from allennlp.data.dataset import Batch
+from allennlp.data.fields import TextField
+from allennlp.data.instance import Instance
+from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
+from allennlp.data.vocabulary import Vocabulary
+from gector.bert_token_embedder import PretrainedBertEmbedder
+from gector.tokenizer_indexer import PretrainedBertIndexer
+
+
+class TestPretrainedBertEmbedder(ModelTestCase):
+    """Test token embedder for BERT model."""
+
+    def setUp(self):
+        """Set up tokenizer and indexer."""
+
+        super().setUp()
+
+        self.tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
+        vocab_path = "data/output_vocabulary"
+        self.vocab = Vocabulary.from_files(vocab_path)
+        self.model_name = "bert-base-cased"
+        self.token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            do_lowercase=False,
+            max_pieces_per_token=5,
+            special_tokens_fix=0,
+        )
+
+    def test_without_offsets(self):
+        """Test input without offsets."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=0,
+        )
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        result = token_embedder(input_ids)
+
+        assert list(result.shape) == [2, 5, 768]
+
+    def test_without_offsets_special_tokens_fix_on(self):
+        """Test input without offsets with special tokens fix on."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        result = token_embedder(input_ids)
+
+        assert list(result.shape) == [2, 5, 768]
+
+    def test_with_offsets(self):
+        """Test input with offsets."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=0,
+        )
+
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        offsets = torch.LongTensor([[0, 2, 4], [1, 0, 0]])
+
+        result = token_embedder(input_ids, offsets=offsets)
+
+        assert list(result.shape) == [2, 3, 768]
+
+    def test_with_offsets_special_tokens_fix_on(self):
+        """Test input with offsets with special tokens fix on."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        offsets = torch.LongTensor([[0, 2, 4], [1, 0, 0]])
+
+        result = token_embedder(input_ids, offsets=offsets)
+
+        assert list(result.shape) == [2, 3, 768]
+
+    def test_end_to_end(self):
+        """Test token embedder end-to-end."""
+
+        sentence1 = "the quickest quick brown fox jumped over the lazy dog"
+        tokens1 = self.tokenizer.tokenize(sentence1)
+
+        sentence2 = "the quick brown fox jumped over the laziest lazy elmo"
+        tokens2 = self.tokenizer.tokenize(sentence2)
+
+        instance1 = Instance(
+            {"tokens": TextField(tokens1, {"bert": self.token_indexer})}
+        )
+        instance2 = Instance(
+            {"tokens": TextField(tokens2, {"bert": self.token_indexer})}
+        )
+
+        batch = Batch([instance1, instance2])
+        batch.index_instances(self.vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+
+        assert tokens["bert"].tolist() == [
+            [
+                1103,
+                3613,
+                2556,
+                3613,
+                3058,
+                17594,
+                4874,
+                1166,
+                1103,
+                16688,
+                3676,
+                0,
+                0,
+            ],
+            [
+                1103,
+                3613,
+                3058,
+                17594,
+                4874,
+                1166,
+                1103,
+                2495,
+                15039,
+                2050,
+                16688,
+                8468,
+                3702,
+            ],
+        ]
+
+        assert tokens["bert-offsets"].tolist() == [
+            [0, 1, 3, 4, 5, 6, 7, 8, 9, 10],
+            [0, 1, 2, 3, 4, 5, 6, 7, 10, 11],
+        ]
+
+        token_embedder = PretrainedBertEmbedder(
+            self.model_name,
+            requires_grad=False,
+            top_layer_only=False,
+            special_tokens_fix=0,
+        )
+
+        bert_vectors = token_embedder(tokens["bert"])
+        assert list(bert_vectors.shape) == [2, 13, 768]
+
+        # Offsets, should get 10 vectors back.
+        bert_vectors = token_embedder(
+            tokens["bert"], offsets=tokens["bert-offsets"]
+        )
+        assert list(bert_vectors.shape) == [2, 10, 768]
+
+        # Now try top_layer_only = True
+        tlo_embedder = PretrainedBertEmbedder(
+            self.model_name, top_layer_only=True, special_tokens_fix=1
+        )
+        bert_vectors = tlo_embedder(tokens["bert"])
+        assert list(bert_vectors.shape) == [2, 13, 768]
+
+        bert_vectors = tlo_embedder(
+            tokens["bert"], offsets=tokens["bert-offsets"]
+        )
+        assert list(bert_vectors.shape) == [2, 10, 768]
+
+    def test_max_length(self):
+        """Test that max input length works."""
+
+        token_embedder = PretrainedBertEmbedder(
+            self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=0,
+        )
+
+        sentence = "the " * 512
+        tokens = self.tokenizer.tokenize(sentence)
+
+        instance = Instance(
+            {"tokens": TextField(tokens, {"bert": self.token_indexer})}
+        )
+
+        batch = Batch([instance])
+        batch.index_instances(self.vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+        token_embedder(tokens["bert"], tokens["bert-offsets"])
+
+    def test_max_length_raise_error(self):
+        """Test that input greater than max length raises error."""
+
+        token_embedder = PretrainedBertEmbedder(
+            self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=0,
+        )
+
+        sentence = "the " * 514
+        tokens = self.tokenizer.tokenize(sentence)
+
+        instance = Instance(
+            {"tokens": TextField(tokens, {"bert": self.token_indexer})}
+        )
+
+        batch = Batch([instance])
+        batch.index_instances(self.vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+        with pytest.raises(IndexError):
+            token_embedder(tokens["bert"], tokens["bert-offsets"])

--- a/tests/test_roberta_embedder.py
+++ b/tests/test_roberta_embedder.py
@@ -5,8 +5,7 @@ from allennlp.common.testing import ModelTestCase
 from allennlp.data.dataset import Batch
 from allennlp.data.fields import TextField
 from allennlp.data.instance import Instance
-from allennlp.data.tokenizers import WordTokenizer
-from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
+from allennlp.data import Token
 from allennlp.data.vocabulary import Vocabulary
 from gector.bert_token_embedder import PretrainedBertEmbedder
 from gector.tokenizer_indexer import PretrainedBertIndexer
@@ -16,11 +15,10 @@ class TestRobertaEmbedder(ModelTestCase):
     """Test token embedder for RoBERTa model."""
 
     def setUp(self):
-        """Set up tokenizer and indexer."""
+        """Set up indexer."""
 
         super().setUp()
 
-        self.tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
         vocab_path = "data/output_vocabulary"
         self.vocab = Vocabulary.from_files(vocab_path)
         self.model_name = "roberta-base"
@@ -97,10 +95,10 @@ class TestRobertaEmbedder(ModelTestCase):
         """Test token embedder end-to-end."""
 
         sentence1 = "the quickest quick brown fox jumped over the lazy dog"
-        tokens1 = self.tokenizer.tokenize(sentence1)
+        tokens1 = [Token(word) for word in sentence1.split()]
 
         sentence2 = "the quick brown fox jumped over the laziest lazy elmo"
-        tokens2 = self.tokenizer.tokenize(sentence2)
+        tokens2 = [Token(word) for word in sentence2.split()]
 
         instance1 = Instance(
             {"tokens": TextField(tokens1, {"bert": self.token_indexer})}
@@ -178,7 +176,7 @@ class TestRobertaEmbedder(ModelTestCase):
         )
 
         sentence = "the " * 512
-        tokens = self.tokenizer.tokenize(sentence)
+        tokens = [Token(word) for word in sentence.split()]
 
         instance = Instance(
             {"tokens": TextField(tokens, {"bert": self.token_indexer})}
@@ -203,7 +201,7 @@ class TestRobertaEmbedder(ModelTestCase):
         )
 
         sentence = "the " * 514
-        tokens = self.tokenizer.tokenize(sentence)
+        tokens = [Token(word) for word in sentence.split()]
 
         instance = Instance(
             {"tokens": TextField(tokens, {"bert": self.token_indexer})}

--- a/tests/test_roberta_embedder.py
+++ b/tests/test_roberta_embedder.py
@@ -166,7 +166,7 @@ class TestRobertaEmbedder(ModelTestCase):
         assert list(bert_vectors.shape) == [2, 10, 768]
 
     def test_max_length(self):
-        """Test that max input length works."""
+        """Test that max input length works (default max len = 512)."""
 
         token_embedder = PretrainedBertEmbedder(
             self.model_name,
@@ -191,7 +191,7 @@ class TestRobertaEmbedder(ModelTestCase):
         token_embedder(tokens["bert"], tokens["bert-offsets"])
 
     def test_max_length_raise_error(self):
-        """Test that input greater than max length raises error."""
+        """Test that input greater than max length (default = 512) raises error."""
 
         token_embedder = PretrainedBertEmbedder(
             self.model_name,

--- a/tests/test_roberta_embedder.py
+++ b/tests/test_roberta_embedder.py
@@ -1,0 +1,219 @@
+import torch
+import pytest
+
+from allennlp.common.testing import ModelTestCase
+from allennlp.data.dataset import Batch
+from allennlp.data.fields import TextField
+from allennlp.data.instance import Instance
+from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
+from allennlp.data.vocabulary import Vocabulary
+from gector.bert_token_embedder import PretrainedBertEmbedder
+from gector.tokenizer_indexer import PretrainedBertIndexer
+
+
+class TestRobertaEmbedder(ModelTestCase):
+    """Test token embedder for RoBERTa model."""
+
+    def setUp(self):
+        """Set up tokenizer and indexer."""
+
+        super().setUp()
+
+        self.tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
+        vocab_path = "data/output_vocabulary"
+        self.vocab = Vocabulary.from_files(vocab_path)
+        self.model_name = "roberta-base"
+        self.token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            do_lowercase=False,
+            max_pieces_per_token=5,
+            special_tokens_fix=1,
+        )
+
+    def test_without_offsets(self):
+        """Test input without offsets."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        result = token_embedder(input_ids)
+
+        assert list(result.shape) == [2, 5, 768]
+
+    def test_without_offsets_special_tokens_fix_off(self):
+        """Test input without offsets with special tokens fix off."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=0,
+        )
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        result = token_embedder(input_ids)
+
+        assert list(result.shape) == [2, 5, 768]
+
+    def test_with_offsets(self):
+        """Test input with offsets."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        offsets = torch.LongTensor([[0, 2, 4], [1, 0, 0]])
+
+        result = token_embedder(input_ids, offsets=offsets)
+
+        assert list(result.shape) == [2, 3, 768]
+
+    def test_with_offsets_special_tokens_fix_off(self):
+        """Test input with offsets with special tokens fix off."""
+
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=0,
+        )
+
+        input_ids = torch.LongTensor([[3, 5, 9, 1, 2], [1, 5, 0, 0, 0]])
+        offsets = torch.LongTensor([[0, 2, 4], [1, 0, 0]])
+
+        result = token_embedder(input_ids, offsets=offsets)
+
+        assert list(result.shape) == [2, 3, 768]
+
+    def test_end_to_end(self):
+        """Test token embedder end-to-end."""
+
+        sentence1 = "the quickest quick brown fox jumped over the lazy dog"
+        tokens1 = self.tokenizer.tokenize(sentence1)
+
+        sentence2 = "the quick brown fox jumped over the laziest lazy elmo"
+        tokens2 = self.tokenizer.tokenize(sentence2)
+
+        instance1 = Instance(
+            {"tokens": TextField(tokens1, {"bert": self.token_indexer})}
+        )
+        instance2 = Instance(
+            {"tokens": TextField(tokens2, {"bert": self.token_indexer})}
+        )
+
+        batch = Batch([instance1, instance2])
+        batch.index_instances(self.vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+
+        assert tokens["bert"].tolist() == [
+            [627, 29155, 2119, 6219, 23602, 4262, 81, 5, 22414, 2335, 0, 0],
+            [
+                627,
+                2119,
+                6219,
+                23602,
+                4262,
+                81,
+                5,
+                40154,
+                7098,
+                22414,
+                1615,
+                4992,
+            ],
+        ]
+
+        assert tokens["bert-offsets"].tolist() == [
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            [0, 1, 2, 3, 4, 5, 6, 7, 9, 10],
+        ]
+
+        token_embedder = PretrainedBertEmbedder(
+            self.model_name,
+            requires_grad=False,
+            top_layer_only=False,
+            special_tokens_fix=1,
+        )
+
+        bert_vectors = token_embedder(tokens["bert"])
+        assert list(bert_vectors.shape) == [2, 12, 768]
+
+        # Offsets, should get 10 vectors back.
+        bert_vectors = token_embedder(
+            tokens["bert"], offsets=tokens["bert-offsets"]
+        )
+        assert list(bert_vectors.shape) == [2, 10, 768]
+
+        # Now try top_layer_only = True
+        tlo_embedder = PretrainedBertEmbedder(
+            self.model_name, top_layer_only=True, special_tokens_fix=1
+        )
+        bert_vectors = tlo_embedder(tokens["bert"])
+        assert list(bert_vectors.shape) == [2, 12, 768]
+
+        bert_vectors = tlo_embedder(
+            tokens["bert"], offsets=tokens["bert-offsets"]
+        )
+        assert list(bert_vectors.shape) == [2, 10, 768]
+
+    def test_max_length(self):
+        """Test that max input length works."""
+
+        token_embedder = PretrainedBertEmbedder(
+            self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+
+        sentence = "the " * 512
+        tokens = self.tokenizer.tokenize(sentence)
+
+        instance = Instance(
+            {"tokens": TextField(tokens, {"bert": self.token_indexer})}
+        )
+
+        batch = Batch([instance])
+        batch.index_instances(self.vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+        token_embedder(tokens["bert"], tokens["bert-offsets"])
+
+    def test_max_length_raise_error(self):
+        """Test that input greater than max length raises error."""
+
+        token_embedder = PretrainedBertEmbedder(
+            self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+
+        sentence = "the " * 514
+        tokens = self.tokenizer.tokenize(sentence)
+
+        instance = Instance(
+            {"tokens": TextField(tokens, {"bert": self.token_indexer})}
+        )
+
+        batch = Batch([instance])
+        batch.index_instances(self.vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+        with pytest.raises(IndexError):
+            token_embedder(tokens["bert"], tokens["bert-offsets"])

--- a/tests/test_seq2labels.py
+++ b/tests/test_seq2labels.py
@@ -1,0 +1,101 @@
+import torch
+import numpy as np
+
+from allennlp.common.testing import ModelTestCase
+from allennlp.common.testing import ModelTestCase
+from allennlp.data.dataset import Batch
+from allennlp.data.fields import TextField
+from allennlp.data.instance import Instance
+from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
+from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
+from allennlp.data.vocabulary import Vocabulary
+
+from gector.bert_token_embedder import PretrainedBertEmbedder
+from gector.tokenizer_indexer import PretrainedBertIndexer
+from gector.seq2labels_model import Seq2Labels
+
+
+class TestSeq2Labels(ModelTestCase):
+    """Test class for Seq2Labels model."""
+
+    def setUp(self):
+        """Set up indexers, embedders and dataset."""
+
+        super(TestSeq2Labels, self).setUp()
+
+        tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
+        vocab_path = "data/output_vocabulary"
+        self.vocab = Vocabulary.from_files(vocab_path)
+        self.model_name = "roberta-base"
+        token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            do_lowercase=False,
+            max_pieces_per_token=5,
+            special_tokens_fix=1,
+        )
+        token_embedder = PretrainedBertEmbedder(
+            pretrained_model=self.model_name,
+            requires_grad=False,
+            top_layer_only=True,
+            special_tokens_fix=1,
+        )
+
+        embedders = {"bert": token_embedder}
+
+        self.text_field_embedder = BasicTextFieldEmbedder(
+            token_embedders=embedders,
+            embedder_to_indexer_map={"bert": ["bert", "bert-offsets"]},
+            allow_unmatched_keys=True,
+        )
+
+        self.device = torch.device(
+            "cuda:0" if torch.cuda.is_available() else "cpu"
+        )
+
+        sentence1 = "the quickest quick brown fox jumped over the lazy dog"
+        tokens1 = tokenizer.tokenize(sentence1)
+
+        sentence2 = "the quick brown fox jumped over the laziest lazy elmo"
+        tokens2 = tokenizer.tokenize(sentence2)
+
+        instance1 = Instance(
+            {"tokens": TextField(tokens1, {"bert": token_indexer})}
+        )
+        instance2 = Instance(
+            {"tokens": TextField(tokens2, {"bert": token_indexer})}
+        )
+
+        self.batch = Batch([instance1, instance2])
+
+    def test_forward_pass_runs_correctly(self):
+        """Test if forward pass returns correct output."""
+
+        self.batch.index_instances(self.vocab)
+        padding_lengths = self.batch.get_padding_lengths()
+        training_tensors = self.batch.as_tensor_dict(padding_lengths)
+
+        model = Seq2Labels(
+            vocab=self.vocab,
+            text_field_embedder=self.text_field_embedder,
+            confidence=0,
+            del_confidence=0,
+        ).to(self.device)
+
+        output_dict = model(**training_tensors)
+        output_dict = model.decode(output_dict)
+
+        assert set(output_dict.keys()) == set(
+            [
+                "logits_labels",
+                "logits_d_tags",
+                "class_probabilities_labels",
+                "class_probabilities_d_tags",
+                "max_error_probability",
+                "labels",
+                "d_tags",
+            ]
+        )
+        probs = output_dict["class_probabilities_labels"][0].data.numpy()
+
+        np.testing.assert_almost_equal(np.sum(probs, -1), np.full((10), 1), 5)

--- a/tests/test_seq2labels.py
+++ b/tests/test_seq2labels.py
@@ -6,8 +6,7 @@ from allennlp.common.testing import ModelTestCase
 from allennlp.data.dataset import Batch
 from allennlp.data.fields import TextField
 from allennlp.data.instance import Instance
-from allennlp.data.tokenizers import WordTokenizer
-from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
+from allennlp.data import Token
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.data.vocabulary import Vocabulary
 
@@ -24,7 +23,6 @@ class TestSeq2Labels(ModelTestCase):
 
         super(TestSeq2Labels, self).setUp()
 
-        tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
         vocab_path = "data/output_vocabulary"
         self.vocab = Vocabulary.from_files(vocab_path)
         self.model_name = "roberta-base"
@@ -54,10 +52,10 @@ class TestSeq2Labels(ModelTestCase):
         )
 
         sentence1 = "the quickest quick brown fox jumped over the lazy dog"
-        tokens1 = tokenizer.tokenize(sentence1)
+        tokens1 = [Token(word) for word in sentence1.split()]
 
         sentence2 = "the quick brown fox jumped over the laziest lazy elmo"
-        tokens2 = tokenizer.tokenize(sentence2)
+        tokens2 = [Token(word) for word in sentence2.split()]
 
         instance1 = Instance(
             {"tokens": TextField(tokens1, {"bert": token_indexer})}

--- a/tests/test_token_indexer.py
+++ b/tests/test_token_indexer.py
@@ -1,10 +1,9 @@
 """Tests for the PretrainedBertIndexer module."""
 
-from allennlp.data.tokenizers import WordTokenizer
 from allennlp.common.testing import ModelTestCase
 from gector.tokenizer_indexer import PretrainedBertIndexer
-from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
 from allennlp.data.vocabulary import Vocabulary
+from allennlp.data import Token
 
 
 class TestPretrainedTransformerIndexer(ModelTestCase):
@@ -15,10 +14,9 @@ class TestPretrainedTransformerIndexer(ModelTestCase):
 
         super().setUp()
 
-        tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
         sentence = "the Quick brown fox jumped over the laziest lazy elmo"
         vocab_path = "data/output_vocabulary"
-        self.tokens = tokenizer.tokenize(sentence)
+        self.tokens = [Token(word) for word in sentence.split()]
         self.vocab = Vocabulary.from_files(vocab_path)
         self.model_name = "roberta-base"
 
@@ -36,7 +34,7 @@ class TestPretrainedTransformerIndexer(ModelTestCase):
         )
         assert indexed_tokens["bert"] == [
             627,
-            2119,
+            13287,
             6219,
             23602,
             4262,
@@ -52,7 +50,7 @@ class TestPretrainedTransformerIndexer(ModelTestCase):
         assert indexed_tokens["mask"] == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
     def test_toggle_special_tokens_fix(self):
-        """Test togging special_tokens_fix to be False"""
+        """Test toggling special_tokens_fix to be False"""
         token_indexer = PretrainedBertIndexer(
             pretrained_model=self.model_name,
             max_pieces_per_token=5,
@@ -66,7 +64,7 @@ class TestPretrainedTransformerIndexer(ModelTestCase):
 
         assert indexed_tokens["bert"] == [
             627,
-            2119,
+            13287,
             6219,
             23602,
             4262,

--- a/tests/test_token_indexer.py
+++ b/tests/test_token_indexer.py
@@ -1,92 +1,249 @@
 """Tests for the PretrainedBertIndexer module."""
-import unittest
-import torch
 
 from allennlp.data.tokenizers import WordTokenizer
+from allennlp.common.testing import ModelTestCase
 from gector.tokenizer_indexer import PretrainedBertIndexer
 from allennlp.data.tokenizers.word_splitter import BertBasicWordSplitter
 from allennlp.data.vocabulary import Vocabulary
 
 
-class TestPretrainedTransformerIndexer(unittest.TestCase):
-    """
-    A test case that tests PretrainedBertIndexer methods.
-
-    Attributes:
-    tokens : List[Token]
-        List of AllenNLP Token objects
-
-    vocab : Vocabulary object
-        Vocabularies from pretrained transformers
-
-    model_name : str
-        Pre-trained model name
-
-    """
+class TestPretrainedTransformerIndexer(ModelTestCase):
+    """A test case that tests PretrainedBertIndexer methods."""
 
     def setUp(self):
-        """Initial setup."""
+        """Set up tokenizer and indexer."""
+
+        super().setUp()
+
         tokenizer = WordTokenizer(word_splitter=BertBasicWordSplitter())
         sentence = "the Quick brown fox jumped over the laziest lazy elmo"
-        vocab_path = "../data/output_vocabulary"
+        vocab_path = "data/output_vocabulary"
         self.tokens = tokenizer.tokenize(sentence)
         self.vocab = Vocabulary.from_files(vocab_path)
-        self.model_name = 'roberta-base'
-     
+        self.model_name = "roberta-base"
+
     def test_do_lowercase(self):
         """Test tokenizer to handle setting do_lowercase to be True"""
-        token_indexer = PretrainedBertIndexer(pretrained_model=self.model_name, max_pieces_per_token=5,
-                                              do_lowercase=True, max_pieces=512,
-                                              special_tokens_fix=1)
-        indexed_tokens = token_indexer.tokens_to_indices(self.tokens, self.vocab, self.model_name)
-        self.assertEqual(indexed_tokens['bert'], [627, 2119, 6219, 23602, 4262, 81, 5, 40154,
-                             7098, 22414, 1615, 4992])
-        self.assertEqual(indexed_tokens['bert-offsets'], [0, 1, 2, 3, 4, 5, 6, 7, 9, 10])
-        self.assertEqual(indexed_tokens['mask'], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            max_pieces_per_token=5,
+            do_lowercase=True,
+            max_pieces=512,
+            special_tokens_fix=1,
+        )
+        indexed_tokens = token_indexer.tokens_to_indices(
+            self.tokens, self.vocab, self.model_name
+        )
+        assert indexed_tokens["bert"] == [
+            627,
+            2119,
+            6219,
+            23602,
+            4262,
+            81,
+            5,
+            40154,
+            7098,
+            22414,
+            1615,
+            4992,
+        ]
+        assert indexed_tokens["bert-offsets"] == [0, 1, 2, 3, 4, 5, 6, 7, 9, 10]
+        assert indexed_tokens["mask"] == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
     def test_toggle_special_tokens_fix(self):
         """Test togging special_tokens_fix to be False"""
-        token_indexer = PretrainedBertIndexer(pretrained_model=self.model_name, max_pieces_per_token=5,
-                                              do_lowercase=True, max_pieces=512,
-                                              special_tokens_fix=0)
-        indexed_tokens = token_indexer.tokens_to_indices(self.tokens, self.vocab, self.model_name)
+        token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            max_pieces_per_token=5,
+            do_lowercase=True,
+            max_pieces=512,
+            special_tokens_fix=0,
+        )
+        indexed_tokens = token_indexer.tokens_to_indices(
+            self.tokens, self.vocab, self.model_name
+        )
 
-        self.assertEqual(indexed_tokens['bert'], [627, 2119, 6219, 23602, 4262, 81, 5, 40154,
-                             7098, 22414, 1615, 4992])
-        self.assertEqual(indexed_tokens['bert-offsets'], [0, 1, 2, 3, 4, 5, 6, 7, 9, 10])
-        self.assertEqual(indexed_tokens['mask'], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        assert indexed_tokens["bert"] == [
+            627,
+            2119,
+            6219,
+            23602,
+            4262,
+            81,
+            5,
+            40154,
+            7098,
+            22414,
+            1615,
+            4992,
+        ]
+        assert indexed_tokens["bert-offsets"] == [0, 1, 2, 3, 4, 5, 6, 7, 9, 10]
+        assert indexed_tokens["mask"] == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
     def test_truncate_window(self):
         """Test the functionality of truncating word pieces"""
-        token_indexer = PretrainedBertIndexer(pretrained_model=self.model_name, max_pieces_per_token=5,
-                                              do_lowercase=True, max_pieces=5,
-                                              special_tokens_fix=1)
-        indexed_tokens = token_indexer.tokens_to_indices(self.tokens, self.vocab, self.model_name)       
+        token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            max_pieces_per_token=5,
+            do_lowercase=True,
+            max_pieces=5,
+            special_tokens_fix=1,
+        )
+        indexed_tokens = token_indexer.tokens_to_indices(
+            self.tokens, self.vocab, self.model_name
+        )
 
-        self.assertEqual(indexed_tokens['bert'], [])
-        self.assertEqual(indexed_tokens['bert-offsets'], [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1])
-        self.assertEqual(indexed_tokens['mask'], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        assert indexed_tokens["bert"] == []
+        assert indexed_tokens["bert-offsets"] == [
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+            -1,
+        ]
+        assert indexed_tokens["mask"] == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
     def test_as_padded_tensor_dict(self):
         """Test the method as_padded_tensor_dict"""
-        tokens = {'bert': [50265, 37158, 15, 1012, 2156, 89, 32, 460, 5,
-        12043, 268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043,
-        7768, 479], 'bert-offsets': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12,
-        13, 15, 16, 17, 18, 19, 20, 21, 22], 'mask': [1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]}
-        padding_lengths = {'bert': 42, 'bert-offsets': 41, 'mask': 41, 'num_tokens': 42}
-        desired_num_tokens = {'bert': 42, 'bert-offsets': 41, 'mask': 41}
+        tokens = {
+            "bert": [
+                50265,
+                37158,
+                15,
+                1012,
+                2156,
+                89,
+                32,
+                460,
+                5,
+                12043,
+                268,
+                8,
+                4131,
+                22761,
+                13659,
+                49,
+                1351,
+                8,
+                11360,
+                7,
+                12043,
+                7768,
+                479,
+            ],
+            "bert-offsets": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                11,
+                12,
+                13,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+            ],
+            "mask": [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ],
+        }
+        padding_lengths = {
+            "bert": 42,
+            "bert-offsets": 41,
+            "mask": 41,
+            "num_tokens": 42,
+        }
+        desired_num_tokens = {"bert": 42, "bert-offsets": 41, "mask": 41}
 
-        token_indexer = PretrainedBertIndexer(pretrained_model=self.model_name, max_pieces_per_token=5,
-                                              do_lowercase=True, max_pieces=512,
-                                              special_tokens_fix=1)
+        token_indexer = PretrainedBertIndexer(
+            pretrained_model=self.model_name,
+            max_pieces_per_token=5,
+            do_lowercase=True,
+            max_pieces=512,
+            special_tokens_fix=1,
+        )
 
-        padded_tensor = token_indexer.pad_token_sequence(tokens, desired_num_tokens, padding_lengths)
-        self.assertEqual(padded_tensor['bert'], [50265, 37158, 15, 1012, 2156,
-        89, 32, 460, 5, 12043, 268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360,
-        7, 12043, 7768, 479, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        padded_tensor = token_indexer.pad_token_sequence(
+            tokens, desired_num_tokens, padding_lengths
+        )
+        assert padded_tensor["bert"] == [
+            50265,
+            37158,
+            15,
+            1012,
+            2156,
+            89,
+            32,
+            460,
+            5,
+            12043,
+            268,
+            8,
+            4131,
+            22761,
+            13659,
+            49,
+            1351,
+            8,
+            11360,
+            7,
+            12043,
+            7768,
+            479,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,135 +1,776 @@
 """Tests for GECToR custom tokenization utilities"""
 
 from gector.tokenization import *
-import unittest
 from transformers import AutoTokenizer
+from allennlp.common.testing import AllenNlpTestCase
 
-class TokenizationTests(unittest.TestCase):
+
+class TokenizationTests(AllenNlpTestCase):
     """A test class that tests the GECToR custom tokenization utilities."""
 
     def test_get_bpe_groups(self):
         """Test get_bpe_groups method with an input sentence."""
-        token_offsets = [(0, 6), (7, 15), (16, 18), (19, 21), (22, 23), (24, 29),
-        (30, 33), (34, 40), (41, 44), (45, 57), (58, 61), (62, 70), (71, 81),
-        (82, 87), (88, 94), (95, 98), (99, 108), (109, 111), (112, 121), (122, 131),
-        (132, 133)]
-        bpe_offsets = [(0, 6), (7, 15), (16, 18), (19, 21), (22, 23), (24, 29),
-        (30, 33), (34, 40), (41, 44), (45, 54), (54, 57), (58, 61), (62, 70),
-        (71, 74), (74, 81), (82, 87), (88, 94), (95, 98), (99, 108), (109, 111),
-        (112, 121), (122, 131),(132, 133)]
-        input_ids = [50265, 37158, 15, 1012, 2156, 89, 32, 460, 5, 12043, 268, 8,
-        4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768, 479]
-        expected_results = ([[0], [1], [2], [3], [4], [5], [6], [7], [8], [9, 10],
-        [11], [12], [13, 14], [15], [16], [17], [18], [19], [20], [21], [22]],
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-        20, 21, 22])
+        token_offsets = [
+            (0, 6),
+            (7, 15),
+            (16, 18),
+            (19, 21),
+            (22, 23),
+            (24, 29),
+            (30, 33),
+            (34, 40),
+            (41, 44),
+            (45, 57),
+            (58, 61),
+            (62, 70),
+            (71, 81),
+            (82, 87),
+            (88, 94),
+            (95, 98),
+            (99, 108),
+            (109, 111),
+            (112, 121),
+            (122, 131),
+            (132, 133),
+        ]
+        bpe_offsets = [
+            (0, 6),
+            (7, 15),
+            (16, 18),
+            (19, 21),
+            (22, 23),
+            (24, 29),
+            (30, 33),
+            (34, 40),
+            (41, 44),
+            (45, 54),
+            (54, 57),
+            (58, 61),
+            (62, 70),
+            (71, 74),
+            (74, 81),
+            (82, 87),
+            (88, 94),
+            (95, 98),
+            (99, 108),
+            (109, 111),
+            (112, 121),
+            (122, 131),
+            (132, 133),
+        ]
+        input_ids = [
+            50265,
+            37158,
+            15,
+            1012,
+            2156,
+            89,
+            32,
+            460,
+            5,
+            12043,
+            268,
+            8,
+            4131,
+            22761,
+            13659,
+            49,
+            1351,
+            8,
+            11360,
+            7,
+            12043,
+            7768,
+            479,
+        ]
+        expected_results = (
+            [
+                [0],
+                [1],
+                [2],
+                [3],
+                [4],
+                [5],
+                [6],
+                [7],
+                [8],
+                [9, 10],
+                [11],
+                [12],
+                [13, 14],
+                [15],
+                [16],
+                [17],
+                [18],
+                [19],
+                [20],
+                [21],
+                [22],
+            ],
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+            ],
+        )
         tested_results = get_bpe_groups(token_offsets, bpe_offsets, input_ids)
 
-        self.assertEqual(expected_results == tested_results)
+        assert expected_results == tested_results
 
     def test_reduce_input_ids(self):
         """Test reduce_input_ids method with an input sentence."""
-        input_ids = [50265, 37158, 15, 1012, 2156, 89, 32, 460, 5, 12043, 268,
-        8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768, 479]
-        bpe_groups = [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9, 10], [11],
-        [12], [13, 14], [15], [16], [17], [18], [19], [20], [21], [22]]
-        saved_ids = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 20, 21, 22]
-        expected_results = ([50265, 37158, 15, 1012, 2156, 89, 32, 460, 5, 12043,
-        268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768, 479],
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 22])
+        input_ids = [
+            50265,
+            37158,
+            15,
+            1012,
+            2156,
+            89,
+            32,
+            460,
+            5,
+            12043,
+            268,
+            8,
+            4131,
+            22761,
+            13659,
+            49,
+            1351,
+            8,
+            11360,
+            7,
+            12043,
+            7768,
+            479,
+        ]
+        bpe_groups = [
+            [0],
+            [1],
+            [2],
+            [3],
+            [4],
+            [5],
+            [6],
+            [7],
+            [8],
+            [9, 10],
+            [11],
+            [12],
+            [13, 14],
+            [15],
+            [16],
+            [17],
+            [18],
+            [19],
+            [20],
+            [21],
+            [22],
+        ]
+        saved_ids = [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+        ]
+        expected_results = (
+            [
+                50265,
+                37158,
+                15,
+                1012,
+                2156,
+                89,
+                32,
+                460,
+                5,
+                12043,
+                268,
+                8,
+                4131,
+                22761,
+                13659,
+                49,
+                1351,
+                8,
+                11360,
+                7,
+                12043,
+                7768,
+                479,
+            ],
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                11,
+                12,
+                13,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+            ],
+        )
         tested_results = reduce_input_ids(input_ids, bpe_groups, saved_ids)
 
-        self.assertEqual(expected_results == tested_results)
+        assert expected_results == tested_results
 
     def test_get_offsets_and_reduce_input_ids(self):
         """Test get_offsets_and_reduce_input_ids method with an input sentence."""
-        tokenizer_output = {'input_ids': [[50265, 37158, 15, 1012, 2156, 89, 32,
-        460, 5, 12043, 268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043,
-        7768, 479]], 'attention_mask': [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], 'offset_mapping': [[(0, 6), (7, 15),
-        (16, 18), (19, 21), (22, 23), (24, 29), (30, 33), (34, 40), (41, 44),
-        (45, 54), (54, 57), (58, 61), (62, 70), (71, 74), (74, 81), (82, 87),
-        (88, 94), (95, 98), (99, 108), (109, 111), (112, 121), (122, 131), (132, 133)]]}
-        token_offset_list = [[(0, 6), (7, 15), (16, 18), (19, 21), (22, 23),
-        (24, 29), (30, 33), (34, 40), (41, 44), (45, 57), (58, 61), (62, 70),
-        (71, 81), (82, 87), (88, 94), (95, 98), (99, 108), (109, 111),
-        (112, 121), (122, 131), (132, 133)]]
+        tokenizer_output = {
+            "input_ids": [
+                [
+                    50265,
+                    37158,
+                    15,
+                    1012,
+                    2156,
+                    89,
+                    32,
+                    460,
+                    5,
+                    12043,
+                    268,
+                    8,
+                    4131,
+                    22761,
+                    13659,
+                    49,
+                    1351,
+                    8,
+                    11360,
+                    7,
+                    12043,
+                    7768,
+                    479,
+                ]
+            ],
+            "attention_mask": [
+                [
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                ]
+            ],
+            "offset_mapping": [
+                [
+                    (0, 6),
+                    (7, 15),
+                    (16, 18),
+                    (19, 21),
+                    (22, 23),
+                    (24, 29),
+                    (30, 33),
+                    (34, 40),
+                    (41, 44),
+                    (45, 54),
+                    (54, 57),
+                    (58, 61),
+                    (62, 70),
+                    (71, 74),
+                    (74, 81),
+                    (82, 87),
+                    (88, 94),
+                    (95, 98),
+                    (99, 108),
+                    (109, 111),
+                    (112, 121),
+                    (122, 131),
+                    (132, 133),
+                ]
+            ],
+        }
+        token_offset_list = [
+            [
+                (0, 6),
+                (7, 15),
+                (16, 18),
+                (19, 21),
+                (22, 23),
+                (24, 29),
+                (30, 33),
+                (34, 40),
+                (41, 44),
+                (45, 57),
+                (58, 61),
+                (62, 70),
+                (71, 81),
+                (82, 87),
+                (88, 94),
+                (95, 98),
+                (99, 108),
+                (109, 111),
+                (112, 121),
+                (122, 131),
+                (132, 133),
+            ]
+        ]
         index_name = "bert"
         max_bpe_length = 512
         max_bpe_pieces = 5
-        expected_results = {'bert': [[50265, 37158, 15, 1012, 2156, 89, 32, 460,
-        5, 12043, 268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768,
-        479]], 'bert-offsets': [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 15,
-        16, 17, 18, 19, 20, 21, 22]], 'mask': [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]}
-        tested_results = get_offsets_and_reduce_input_ids(tokenizer_output, token_offset_list,
-                                                          index_name=index_name,
-                                                          max_bpe_length=max_bpe_length,
-                                                          max_bpe_pieces=max_bpe_pieces
-                                                          )
+        expected_results = {
+            "bert": [
+                [
+                    50265,
+                    37158,
+                    15,
+                    1012,
+                    2156,
+                    89,
+                    32,
+                    460,
+                    5,
+                    12043,
+                    268,
+                    8,
+                    4131,
+                    22761,
+                    13659,
+                    49,
+                    1351,
+                    8,
+                    11360,
+                    7,
+                    12043,
+                    7768,
+                    479,
+                ]
+            ],
+            "bert-offsets": [
+                [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    11,
+                    12,
+                    13,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                ]
+            ],
+            "mask": [
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+            ],
+        }
+        tested_results = get_offsets_and_reduce_input_ids(
+            tokenizer_output,
+            token_offset_list,
+            index_name=index_name,
+            max_bpe_length=max_bpe_length,
+            max_bpe_pieces=max_bpe_pieces,
+        )
 
-        self.assertEqual(assert expected_results == tested_results)
+        assert expected_results == tested_results
 
     def test_get_offset_for_tokens(self):
         """Test get_offset_for_tokens method with an input sentence."""
-        tokens = ['$START', 'Everyday', 'on', 'TV', ',', 'there', 'are', 'always',
-        'the', 'entertainers', 'and', 'athletes','dedicating', 'their', 'effort',
-        'and', 'abilities', 'to', 'entertain', 'audiences', '.']
-        
-        expected_results = [(0, 6), (7, 15), (16, 18), (19, 21), (22, 23), (24, 29),
-        (30, 33), (34, 40), (41, 44), (45, 57), (58, 61), (62, 70), (71, 81),
-        (82, 87), (88, 94), (95, 98), (99, 108), (109, 111), (112, 121), (122, 131), (132, 133)]
+        tokens = [
+            "$START",
+            "Everyday",
+            "on",
+            "TV",
+            ",",
+            "there",
+            "are",
+            "always",
+            "the",
+            "entertainers",
+            "and",
+            "athletes",
+            "dedicating",
+            "their",
+            "effort",
+            "and",
+            "abilities",
+            "to",
+            "entertain",
+            "audiences",
+            ".",
+        ]
+
+        expected_results = [
+            (0, 6),
+            (7, 15),
+            (16, 18),
+            (19, 21),
+            (22, 23),
+            (24, 29),
+            (30, 33),
+            (34, 40),
+            (41, 44),
+            (45, 57),
+            (58, 61),
+            (62, 70),
+            (71, 81),
+            (82, 87),
+            (88, 94),
+            (95, 98),
+            (99, 108),
+            (109, 111),
+            (112, 121),
+            (122, 131),
+            (132, 133),
+        ]
         tested_results = get_offset_for_tokens(tokens)
-        self.assertEqual(expected_results == tested_results)
+        assert expected_results == tested_results
 
     def test_get_token_offsets(self):
         """Test get_token_offsets method with an input sentence."""
-        batch = [['$START', 'Everyday', 'on', 'TV', ',', 'there', 'are', 'always',
-        'the', 'entertainers', 'and', 'athletes','dedicating', 'their', 'effort',
-        'and', 'abilities', 'to', 'entertain', 'audiences', '.']]
+        batch = [
+            [
+                "$START",
+                "Everyday",
+                "on",
+                "TV",
+                ",",
+                "there",
+                "are",
+                "always",
+                "the",
+                "entertainers",
+                "and",
+                "athletes",
+                "dedicating",
+                "their",
+                "effort",
+                "and",
+                "abilities",
+                "to",
+                "entertain",
+                "audiences",
+                ".",
+            ]
+        ]
         tested_results = get_token_offsets(batch)
-        expected_results = [[(0, 6), (7, 15), (16, 18), (19, 21), (22, 23), (24, 29),
-        (30, 33), (34, 40), (41, 44), (45, 57), (58, 61), (62, 70), (71, 81), (82, 87),
-        (88, 94), (95, 98), (99, 108), (109, 111), (112, 121), (122, 131), (132, 133)]]
+        expected_results = [
+            [
+                (0, 6),
+                (7, 15),
+                (16, 18),
+                (19, 21),
+                (22, 23),
+                (24, 29),
+                (30, 33),
+                (34, 40),
+                (41, 44),
+                (45, 57),
+                (58, 61),
+                (62, 70),
+                (71, 81),
+                (82, 87),
+                (88, 94),
+                (95, 98),
+                (99, 108),
+                (109, 111),
+                (112, 121),
+                (122, 131),
+                (132, 133),
+            ]
+        ]
 
-        self.assertEqual(expected_results == tested_results)
+        assert expected_results == tested_results
 
     def test_pad_output(self):
         """Test pad_output with an input sentence."""
-        output = {'bert': [[50265, 37158, 15, 1012, 2156, 89, 32, 460, 5, 12043,
-        268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768, 479]],
-        'bert-offsets': [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 15, 16, 17,
-        18, 19, 20, 21, 22]],'mask': [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1]]}
+        output = {
+            "bert": [
+                [
+                    50265,
+                    37158,
+                    15,
+                    1012,
+                    2156,
+                    89,
+                    32,
+                    460,
+                    5,
+                    12043,
+                    268,
+                    8,
+                    4131,
+                    22761,
+                    13659,
+                    49,
+                    1351,
+                    8,
+                    11360,
+                    7,
+                    12043,
+                    7768,
+                    479,
+                ]
+            ],
+            "bert-offsets": [
+                [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    11,
+                    12,
+                    13,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                ]
+            ],
+            "mask": [
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+            ],
+        }
         tested_results = pad_output(output)
-        expected_results = {'bert': [[50265, 37158, 15, 1012, 2156, 89, 32, 460,
-        5, 12043, 268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768,
-        479]], 'bert-offsets': [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 15, 16,
-        17, 18, 19, 20, 21, 22]], 'mask': [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1]]}
+        expected_results = {
+            "bert": [
+                [
+                    50265,
+                    37158,
+                    15,
+                    1012,
+                    2156,
+                    89,
+                    32,
+                    460,
+                    5,
+                    12043,
+                    268,
+                    8,
+                    4131,
+                    22761,
+                    13659,
+                    49,
+                    1351,
+                    8,
+                    11360,
+                    7,
+                    12043,
+                    7768,
+                    479,
+                ]
+            ],
+            "bert-offsets": [
+                [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    11,
+                    12,
+                    13,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                ]
+            ],
+            "mask": [
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+            ],
+        }
 
-        self.assertEqual(expected_results == tested_results)
-
+        assert expected_results == tested_results
 
     def test_tokenize_batch(self):
         """Test tokenize_batch method with an input sentence."""
         index_name = "bert"
-        tokenizer = AutoTokenizer.from_pretrained('roberta-base', do_lower_case=True,
-                                                  do_basic_tokenize=False, use_fast=True)
-        batch_tokens = [['$START', 'Everyday', 'on', 'TV', ',', 'there', 'are', 'always',
-        'the', 'entertainers', 'and', 'athletes','dedicating', 'their', 'effort',
-        'and', 'abilities', 'to', 'entertain', 'audiences', '.']]
+        tokenizer = AutoTokenizer.from_pretrained(
+            "roberta-base",
+            do_lower_case=True,
+            do_basic_tokenize=False,
+            use_fast=True,
+        )
+        batch_tokens = [
+            [
+                "$START",
+                "Everyday",
+                "on",
+                "TV",
+                ",",
+                "there",
+                "are",
+                "always",
+                "the",
+                "entertainers",
+                "and",
+                "athletes",
+                "dedicating",
+                "their",
+                "effort",
+                "and",
+                "abilities",
+                "to",
+                "entertain",
+                "audiences",
+                ".",
+            ]
+        ]
         max_bpe_length = 512
         max_bpe_pieces = 5
-        tested_results = tokenize_batch(tokenizer, batch_tokens, index_name, max_bpe_length, max_bpe_pieces)
-        expected_results = {'bert': [[1629, 4014, 11328, 37158, 15, 1012, 2156, 89, 32, 460, 5,
-        12043, 268, 8, 4131, 22761, 13659, 49, 1351, 8, 11360, 7, 12043, 7768, 479]],
-        'bert-offsets': [[0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23,
-        24]], 'mask': [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]}
+        tested_results = tokenize_batch(
+            tokenizer, batch_tokens, index_name, max_bpe_length, max_bpe_pieces
+        )
+        expected_results = {
+            "bert": [
+                [
+                    1629,
+                    4014,
+                    11328,
+                    37158,
+                    15,
+                    1012,
+                    2156,
+                    89,
+                    32,
+                    460,
+                    5,
+                    12043,
+                    268,
+                    8,
+                    4131,
+                    22761,
+                    13659,
+                    49,
+                    1351,
+                    8,
+                    11360,
+                    7,
+                    12043,
+                    7768,
+                    479,
+                ]
+            ],
+            "bert-offsets": [
+                [
+                    0,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    13,
+                    14,
+                    15,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                ]
+            ],
+            "mask": [
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+            ],
+        }
 
-        self.assertEqual(expected_results == tested_results)
-
-        
-if __name__ == '__main__':
-    unittest.main()
+        assert expected_results == tested_results


### PR DESCRIPTION
This PR adds tests for the token embedder in GECToR, the `Seq2Labels` model and updates the tokenization tests so that they conform to AllenNLP tests.

To test, please set up the environment and run the following command from the project root directory i.e. `gector/`.

```
pytest -v tests
```