### PR TITLE
Update embedder and seq2labels tests to work with allennlp 2.10

### DIFF
--- a/tests/test_bert_embedder.py
+++ b/tests/test_bert_embedder.py
@@ -1,12 +1,12 @@
-import torch
 import pytest
+import torch
 
 from allennlp.common.testing import ModelTestCase
-from allennlp.data.dataset import Batch
+from allennlp.data import Batch, Token
 from allennlp.data.fields import TextField
-from allennlp.data.instance import Instance
-from allennlp.data import Token
-from allennlp.data.vocabulary import Vocabulary
+from allennlp.data import Instance
+from allennlp.data import Vocabulary
+
 from gector.bert_token_embedder import PretrainedBertEmbedder
 from gector.tokenizer_indexer import PretrainedBertIndexer
 
@@ -14,10 +14,10 @@ from gector.tokenizer_indexer import PretrainedBertIndexer
 class TestPretrainedBertEmbedder(ModelTestCase):
     """Test token embedder for BERT model."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up indexer."""
 
-        super().setUp()
+        super().setup_method()
 
         vocab_path = "data/output_vocabulary"
         self.vocab = Vocabulary.from_files(vocab_path)
@@ -112,7 +112,7 @@ class TestPretrainedBertEmbedder(ModelTestCase):
 
         padding_lengths = batch.get_padding_lengths()
         tensor_dict = batch.as_tensor_dict(padding_lengths)
-        tokens = tensor_dict["tokens"]
+        tokens = tensor_dict["tokens"]["bert"]
 
         assert tokens["bert"].tolist() == [
             [
@@ -202,7 +202,7 @@ class TestPretrainedBertEmbedder(ModelTestCase):
 
         padding_lengths = batch.get_padding_lengths()
         tensor_dict = batch.as_tensor_dict(padding_lengths)
-        tokens = tensor_dict["tokens"]
+        tokens = tensor_dict["tokens"]["bert"]
         token_embedder(tokens["bert"], tokens["bert-offsets"])
 
     def test_max_length_raise_error(self):
@@ -227,6 +227,6 @@ class TestPretrainedBertEmbedder(ModelTestCase):
 
         padding_lengths = batch.get_padding_lengths()
         tensor_dict = batch.as_tensor_dict(padding_lengths)
-        tokens = tensor_dict["tokens"]
+        tokens = tensor_dict["tokens"]["bert"]
         with pytest.raises(IndexError):
             token_embedder(tokens["bert"], tokens["bert-offsets"])

--- a/tests/test_roberta_embedder.py
+++ b/tests/test_roberta_embedder.py
@@ -2,11 +2,12 @@ import torch
 import pytest
 
 from allennlp.common.testing import ModelTestCase
-from allennlp.data.dataset import Batch
+from allennlp.data import Batch
 from allennlp.data.fields import TextField
-from allennlp.data.instance import Instance
+from allennlp.data import Instance
 from allennlp.data import Token
-from allennlp.data.vocabulary import Vocabulary
+from allennlp.data import Vocabulary
+
 from gector.bert_token_embedder import PretrainedBertEmbedder
 from gector.tokenizer_indexer import PretrainedBertIndexer
 
@@ -14,10 +15,10 @@ from gector.tokenizer_indexer import PretrainedBertIndexer
 class TestRobertaEmbedder(ModelTestCase):
     """Test token embedder for RoBERTa model."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up indexer."""
 
-        super().setUp()
+        super().setup_method()
 
         vocab_path = "data/output_vocabulary"
         self.vocab = Vocabulary.from_files(vocab_path)
@@ -112,7 +113,7 @@ class TestRobertaEmbedder(ModelTestCase):
 
         padding_lengths = batch.get_padding_lengths()
         tensor_dict = batch.as_tensor_dict(padding_lengths)
-        tokens = tensor_dict["tokens"]
+        tokens = tensor_dict["tokens"]["bert"]
 
         assert tokens["bert"].tolist() == [
             [627, 29155, 2119, 6219, 23602, 4262, 81, 5, 22414, 2335, 0, 0],
@@ -187,7 +188,7 @@ class TestRobertaEmbedder(ModelTestCase):
 
         padding_lengths = batch.get_padding_lengths()
         tensor_dict = batch.as_tensor_dict(padding_lengths)
-        tokens = tensor_dict["tokens"]
+        tokens = tensor_dict["tokens"]["bert"]
         token_embedder(tokens["bert"], tokens["bert-offsets"])
 
     def test_max_length_raise_error(self):
@@ -212,6 +213,6 @@ class TestRobertaEmbedder(ModelTestCase):
 
         padding_lengths = batch.get_padding_lengths()
         tensor_dict = batch.as_tensor_dict(padding_lengths)
-        tokens = tensor_dict["tokens"]
+        tokens = tensor_dict["tokens"]["bert"]
         with pytest.raises(IndexError):
             token_embedder(tokens["bert"], tokens["bert-offsets"])

--- a/tests/test_seq2labels.py
+++ b/tests/test_seq2labels.py
@@ -2,13 +2,13 @@ import torch
 import numpy as np
 
 from allennlp.common.testing import ModelTestCase
-from allennlp.data.dataset import Batch
+from allennlp.data import Batch
 from allennlp.data.fields import TextField
-from allennlp.data.instance import Instance
+from allennlp.data import Instance
 from allennlp.data import Token
-from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
-from allennlp.data.vocabulary import Vocabulary
+from allennlp.data import Vocabulary
 
+from gector.basic_field_embedder import BasicTextFieldEmbedder
 from gector.bert_token_embedder import PretrainedBertEmbedder
 from gector.tokenizer_indexer import PretrainedBertIndexer
 from gector.seq2labels_model import Seq2Labels
@@ -17,10 +17,10 @@ from gector.seq2labels_model import Seq2Labels
 class TestSeq2Labels(ModelTestCase):
     """Test class for Seq2Labels model."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up indexers, embedders and dataset."""
 
-        super(TestSeq2Labels, self).setUp()
+        super(TestSeq2Labels, self).setup_method()
 
         vocab_path = "data/output_vocabulary"
         self.vocab = Vocabulary.from_files(vocab_path)
@@ -80,7 +80,7 @@ class TestSeq2Labels(ModelTestCase):
         ).to(self.device)
 
         output_dict = model(**training_tensors)
-        output_dict = model.decode(output_dict)
+        output_dict = model.make_output_human_readable(output_dict)
 
         assert set(output_dict.keys()) == set(
             [


### PR DESCRIPTION
This PR updates embedder and Seq2Labels model test files to work with latest versions of all packages.