### PR TITLE
Update embedder to not download weights from huggingface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # pytorch weights files
 *.th
+
+# Lock files
+*.lock

--- a/regression_tests/test_regression_data_predictor.py
+++ b/regression_tests/test_regression_data_predictor.py
@@ -139,7 +139,8 @@ def main():
     model_path = download_weights()
 
     # Initialize model
-    model = Predictor.from_path(model_path, predictor_name="gec-predictor")
+    overrides = {"model.text_field_embedder.token_embedders.bert.load_weights": False}
+    model = Predictor.from_path(model_path, predictor_name="gec-predictor", overrides=overrides)
 
     # Generate predictions and compare to previous output.
     predict_and_compare(model)


### PR DESCRIPTION
Add param to embedder to not download weights from huggingface if loading from archive for inference. See allenai/allennlp#5172 for more details.

Only config files will be downloaded from huggingface if `load_weights` is set to False.